### PR TITLE
fix undefined method File.exists?

### DIFF
--- a/lib/rspec_api_documentation/writers/append_json_writer.rb
+++ b/lib/rspec_api_documentation/writers/append_json_writer.rb
@@ -5,7 +5,7 @@ module RspecApiDocumentation
     class AppendJsonWriter < JsonWriter
       def write
         index_file = docs_dir.join("index.json")
-        if File.exists?(index_file) && (output = File.read(index_file)).length >= 2
+        if File.exist?(index_file) && (output = File.read(index_file)).length >= 2
           existing_index_hash = JSON.parse(output)
         end
         File.open(index_file, "w+") do |f|

--- a/lib/rspec_api_documentation/writers/writer.rb
+++ b/lib/rspec_api_documentation/writers/writer.rb
@@ -14,7 +14,7 @@ module RspecApiDocumentation
       end
 
       def self.clear_docs(docs_dir)
-        if File.exists?(docs_dir)
+        if File.exist?(docs_dir)
           FileUtils.rm_rf(docs_dir, :secure => true)
         end
         FileUtils.mkdir_p(docs_dir)

--- a/spec/api_documentation_spec.rb
+++ b/spec/api_documentation_spec.rb
@@ -19,7 +19,7 @@ describe RspecApiDocumentation::ApiDocumentation do
       subject.clear_docs
 
       expect(File.directory?(configuration.docs_dir)).to be_truthy
-      expect(File.exists?(test_file)).to be_falsey
+      expect(File.exist?(test_file)).to be_falsey
     end
   end
 

--- a/spec/writers/html_writer_spec.rb
+++ b/spec/writers/html_writer_spec.rb
@@ -27,7 +27,7 @@ describe RspecApiDocumentation::Writers::HtmlWriter do
 
         writer.write
         index_file = File.join(configuration.docs_dir, "index.html")
-        expect(File.exists?(index_file)).to be_truthy
+        expect(File.exist?(index_file)).to be_truthy
       end
     end
   end

--- a/spec/writers/json_iodocs_writer_spec.rb
+++ b/spec/writers/json_iodocs_writer_spec.rb
@@ -25,7 +25,7 @@ describe RspecApiDocumentation::Writers::JsonIodocsWriter do
     it "should write the index" do
       writer.write
       index_file = File.join(configuration.docs_dir, "apiconfig.json")
-      expect(File.exists?(index_file)).to be_truthy
+      expect(File.exist?(index_file)).to be_truthy
     end
   end
 end

--- a/spec/writers/json_writer_spec.rb
+++ b/spec/writers/json_writer_spec.rb
@@ -24,7 +24,7 @@ describe RspecApiDocumentation::Writers::JSONWriter do
     it "should write the index" do
       writer.write
       index_file = File.join(configuration.docs_dir, "index.json")
-      expect(File.exists?(index_file)).to be_truthy
+      expect(File.exist?(index_file)).to be_truthy
     end
   end
 end

--- a/spec/writers/markdown_writer_spec.rb
+++ b/spec/writers/markdown_writer_spec.rb
@@ -27,7 +27,7 @@ describe RspecApiDocumentation::Writers::MarkdownWriter do
 
         writer.write
         index_file = File.join(configuration.docs_dir, "index.md")
-        expect(File.exists?(index_file)).to be_truthy
+        expect(File.exist?(index_file)).to be_truthy
       end
     end
   end

--- a/spec/writers/slate_writer_spec.rb
+++ b/spec/writers/slate_writer_spec.rb
@@ -27,7 +27,7 @@ describe RspecApiDocumentation::Writers::SlateWriter do
 
         writer.write
         index_file = File.join(configuration.docs_dir, "index.html.md")
-        expect(File.exists?(index_file)).to be_truthy
+        expect(File.exist?(index_file)).to be_truthy
       end
     end
   end

--- a/spec/writers/textile_writer_spec.rb
+++ b/spec/writers/textile_writer_spec.rb
@@ -27,7 +27,7 @@ describe RspecApiDocumentation::Writers::TextileWriter do
 
         writer.write
         index_file = File.join(configuration.docs_dir, "index.textile")
-        expect(File.exists?(index_file)).to be_truthy
+        expect(File.exist?(index_file)).to be_truthy
       end
     end
   end


### PR DESCRIPTION
This pull request standardizes the usage of the `File.exist?` method across the codebase, replacing all instances of the deprecated or incorrect `File.exists?` method. This change improves code consistency and future-proofs the code against deprecation warnings.

Consistency and modernization:

* Replaced all occurrences of `File.exists?` with `File.exist?` in the main library files, including `append_json_writer.rb` and `writer.rb`, to use the correct Ruby method. [[1]](diffhunk://#diff-80dcd1b9ecbe854db9970ad9fdd49295172acea652ace82869637d5cf290a9f3L8-R8) [[2]](diffhunk://#diff-625d22381746366443d69de9c2ddb397555f8697d6482eb0c0326b43071e78feL17-R17)
* Updated all relevant test files to use `File.exist?` instead of `File.exists?`, ensuring consistency in test assertions: `api_documentation_spec.rb`, `html_writer_spec.rb`, `json_iodocs_writer_spec.rb`, `json_writer_spec.rb`, `markdown_writer_spec.rb`, `slate_writer_spec.rb`, and `textile_writer_spec.rb`. [[1]](diffhunk://#diff-3ae400b61495fe11429a6f1a98fe5234eb98dcafa02d9cc165f848733fe151c3L22-R22) [[2]](diffhunk://#diff-c2ea23d1f9b1d1dc92aec6ff4f0b6f83b09ee892001d0d7d337594aa350cb22fL30-R30) [[3]](diffhunk://#diff-f31c1e8666545acb82f56bb6ff0f92cabfbed15d6d929705cb2a2633277750dfL28-R28) [[4]](diffhunk://#diff-028f9b105293042108c5594a8459280676b24b4af4f8a31c7d72a75e92eed151L27-R27) [[5]](diffhunk://#diff-12fae02676950616136fc85c99379fd0a5519a4e57d9215b8df8eaa48ea22661L30-R30) [[6]](diffhunk://#diff-3f70ea12e925b547ced065add590f1aa270cee1891031f02f0f7ee55d86e2cdbL30-R30) [[7]](diffhunk://#diff-6527d4224c3ddf7daec8087384798a786deb0479c6f8572fdc8dd61c6328bed1L30-R30)

Deprecation reference https://ruby-doc.org/core-2.2.0/File.html#method-c-exists-3F